### PR TITLE
Link to docs site from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Millennium Machines Documentation
 This repository contains the source for the Millennium Machines documentation website.
 
+While the documentation is written in Markdown, it is rendered using `mkdocs` and `mkdocs-material`, which allow for some custom formatting. You should view the documentation on the website itself, [https://millenniummachines.github.io/docs](https://millenniummachines.github.io/docs) rather than through the GitHub interface for the best experience.
+
 **CAUTION**: This is a work-in-progress, as we move the current Milo documentation into this repository and allow it to be extended to our other projects. Please continue to submit documentation issues to the specific product issues list.


### PR DESCRIPTION
Adds a link to the documentation site from the GitHub `README.md` so that people view the documentation in the right place.