### PR TITLE
Do not allow multiple pages deploys to run at once

### DIFF
--- a/.github/workflows/generate-github-pages.yml
+++ b/.github/workflows/generate-github-pages.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Check-out Repo
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -93,6 +91,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.repository }}
+      cancel-in-progress: false
     environment:
       name: ${{ github.ref != 'refs/heads/main' && github.ref_name || 'production' }}
       url: ${{ needs.build.outputs.site_url }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # [View the Docs by Clicking here!](https://millenniummachines.github.io/docs)
+
 [![Generate GitHub Pages](https://github.com/MillenniumMachines/millenniummachines.github.io/actions/workflows/generate-github-pages.yml/badge.svg?branch=main)](https://github.com/MillenniumMachines/millenniummachines.github.io/actions/workflows/generate-github-pages.yml)
 
 # Millennium Machines Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,5 +29,5 @@ Docs coming soon! For now, please use the PDF manual.
 ### [MillenniumOS - An "Operations System" for CNC Machines](./millennium-os/index.md)
 
 - [Github Page](https://github.com/MillenniumMachines/MillenniumOS)
-- [Installation](./manual/installation.md)
-- [Usage](./manual/usage.md)
+- [Installation](./millennium-os/manual/installation.md)
+- [Usage](./millennium-os/manual/usage.md)


### PR DESCRIPTION
It's possible, if you click fast enough, to trigger a dev and main deployment at the same time - since these commit and push to the same `gh-pages` branch, it is possible for one branch to push after the other has checked out, which makes the second deployment fail as the checked-out code is now out of date.

We avoid this by setting the deploy concurrency group to `github.repository`.

This branch also contains a quick fix to the MillenniumOS links on the landing page, which were incorrect :facepalm: 