### PR TITLE
Fixup accent color value

### DIFF
--- a/docs/milo/printing/print_guide.md
+++ b/docs/milo/printing/print_guide.md
@@ -67,7 +67,7 @@ To make some features printable without support, some features are printed with 
 | **Name** | **Infill** | **Min. Wall Thickness** | **Material** | **Qty** | **Accent Color** |
 |----------|------------|-------------------------|--------------|--------:|----------------------|
 | [Z Axis Motor Mount             ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Z%20Axis%20STLs/Z%20Motor%20Mount%20x1.stl)                                  | 40%  | 1.6mm | ABS/ASA | 1 | :material-close: No |
-| [Z Axis Bearing Block           ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Z%20Axis%20STLs/%5Ba%5D%20Z%20Axis%20Bearing%20Block%20x1.stl)               | 40%  | 1.6mm | ABS/ASA | 1 | :material-close: No |
+| [Z Axis Bearing Block           ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Z%20Axis%20STLs/%5Ba%5D%20Z%20Axis%20Bearing%20Block%20x1.stl)               | 40%  | 1.6mm | ABS/ASA | 1 | :material-close: Yes |
 | [Z Axis Anti Backlash Nut       ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Z%20Axis%20STLs/Z%20Axis%20Anti%20Backlash%20Nut%20x1.stl)                   | 40%  | 1.6mm | ABS/ASA | 1 | :material-close: No |
 
 ## Main Column


### PR DESCRIPTION
Z Axis Bearing Block filename indicates it should be printed in access color, print guide does not.

```
akonkol@Andrews-MBP Z Axis STLs % pwd
/Users/akonkol/print_queue/Milo-v1.5/STL Files/Minimill Main/Z Axis STLs
akonkol@Andrews-MBP Z Axis STLs % ls -l *Bearing*
-rw-r--r--@ 1 akonkol  staff  362784 Mar 22 12:51 [a] Z Axis Bearing
Block x1.stl
```