### PR TITLE
Fix various linting issues and consistently refer to drag chains

### DIFF
--- a/docs/casa/manual/chapters/10_introduction.md
+++ b/docs/casa/manual/chapters/10_introduction.md
@@ -51,7 +51,6 @@ Before you head out on your journey to create skynet, it's probably a good idea 
 <div class="annotate" markdown>
 - [How to use heat set inserts](https://www.youtube.com/watch?v=cyof7fYFcuQ&list=PL7zrGeKp_8CTDOmpwZr5JnCSJqEghFh9j&index=32)
 - [Electronics connectors and how to use them](https://www.youtube.com/watch?v=y6G_MhQFv3k)
-- [Cable chains and how not to use them](https://www.youtube.com/watch?v=_HiuY015rOY)
 </div>
 
 ---

--- a/docs/milo/bom/sourcing_guide.md
+++ b/docs/milo/bom/sourcing_guide.md
@@ -114,7 +114,7 @@
 
 | **Component**                                      | **Standard**                | **QTY** | **Recommended**                                    |
 |:---------------------------------------------------|-----------------------------|--------:|----------------------------------------------------|
-| 10mmx11mm Cable Chain - Openable (1m)              |                             | 3       | [FYSETC](https://s.click.aliexpress.com/e/_AkGI1l) |
+| 10mmx11mm Cable / Drag Chain - Openable (1m)       |                             | 3       | [FYSETC](https://s.click.aliexpress.com/e/_AkGI1l) |
 | Nylon Cable Ties (less than 5mm wide)              |                             | 100     | [Amazon](https://amzn.to/3NmmzLt)                  |
 | 18AWG\* (min) Mains wiring (neutral, line, ground) |                             | 1       |                                                    |
 | 20AWG Silicone or PTFE Cable (25ft total)          |                             | 1       |                                                    |

--- a/docs/milo/manual/chapters/20_introduction.md
+++ b/docs/milo/manual/chapters/20_introduction.md
@@ -74,7 +74,6 @@ This machine requires an immense amount of T-nuts. In the interest of simplifyin
 
 Linear rail carriages use small ball-bearings to glide smoothly along the profile in the rail. If any of your carriages feel 'gritty' when moving, you should remove the carriages from the rail and give them a good clean with contact cleaner, brake cleaner or another similar non-corrosive degreaser.
 
-
 You must make sure that your carriages are appropriately greased before running your machine. Liberal application of EP2 grease to the carriages will do the trick.
 
 !!! warning
@@ -96,7 +95,7 @@ Before you head out on your journey to create skynet, it's probably a good idea 
 - [How to get started with RepRap firmware on a Fly board](https://www.youtube.com/watch?v=TAT532vIVzU)
 - [CNC basics](https://youtu.be/YBGqknN3gGs?si=ds4zdG03RDS3XUv7)
 - [Electronics connectors and how to use them](https://www.youtube.com/watch?v=y6G_MhQFv3k)
-- [Cable chains and how not to use them](https://www.youtube.com/watch?v=_HiuY015rOY)
+- [Drag chains and how not to use them](https://www.youtube.com/watch?v=_HiuY015rOY)
 </div>
 1. Cold bluing stainless steel, while technically possible, is performed primarily for aesthetic reasons. The cold bluing process does not significantly change its corrosion resistance or any other inherent physical property.
 

--- a/docs/milo/manual/chapters/30_hardware_reference.md
+++ b/docs/milo/manual/chapters/30_hardware_reference.md
@@ -20,7 +20,6 @@ ISO 10642
 
 ---
 
-
 ## Socket Head Cap Bolt (SHCS)
 
 ![Socket head cap bolt wireframe](https://millenniummachines.github.io/docs-dev/milo/manual/img/hardware/shcs.png){: .shadow}
@@ -133,7 +132,7 @@ Used to drive the Z-Axis lead-screw from the 20-tooth pulley above.
 
 ## Brass Lead-screw Nut
 
-![](https://millenniummachines.github.io/docs-dev/milo/manual/img/hardware/brass_leadscrew_nut.png){: .shadow}
+![iBrass Lead-screw Nut](https://millenniummachines.github.io/docs-dev/milo/manual/img/hardware/brass_leadscrew_nut.png){: .shadow}
 
 Used to translate rotational motion of a lead-screw into linear motion of an axis.
 

--- a/docs/milo/manual/chapters/40_y_axis_assembly.md
+++ b/docs/milo/manual/chapters/40_y_axis_assembly.md
@@ -27,6 +27,7 @@ After this has been done, face `C` will now be oriented towards you. When instal
     ![dummy rail](../img/hardware/dummy_rail.png){: .shadow}
 
 ---
+
 ## XY Gantry Plate
 
 !!! info annotate "Components Required"
@@ -40,8 +41,9 @@ After this has been done, face `C` will now be oriented towards you. When instal
      1 x XY Gantry Plate (1)
      1 x XY Drag-Chain Transition (2)
     ```
+
 1. For additional strength this part should be machined :material-saw-blade: but it can be printed :material-printer-3d-nozzle-heat-outline: using the [recommended settings](../../printing/print_guide.md#y-axis-assembly) if necessary.
-2. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#y-axis-assembly#cable-chain-mounts)!
+2. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#drag-chain-mounts)!
 
 Attach the lower rail `Y` carriages using M3x5mm SHCS.
 
@@ -63,7 +65,7 @@ Insert the M3 Heat-set inserts into the XY Drag-Chain Transition.
 ![insert the M3 heat-set inserts in the XY Drag Chain Transition](../img/y_axis_assembly/y_axis_step_3.png){: .shadow}
 
 !!! note
-    You may notice that some kits like LDO’s come with 2 different length of M3 heat insert, the smaller ones are used wherever cable chains attach to and the longer ones are used for everything else.
+    You may notice that some kits like LDO’s come with 2 different length of M3 heat insert, the smaller ones are used wherever drag chains attach to and the longer ones are used for everything else.
 
 ---
 
@@ -72,6 +74,7 @@ Fasten the XY Drag-Chain Transition to the XY plate using M3x20mm SHCS and one M
 ![fasten the XY Drag Chain Transition to the XY plate using M3x20mm SHCS stacked with one M3 washer](../img/y_axis_assembly/y_axis_step_4.png){: .shadow}
 
 ---
+
 ## X and Y Anti-Backlash Nuts
 
 !!! info annotate "Components Required"
@@ -121,7 +124,6 @@ Fasten the X-Axis Anti-Backlash Nut to the top of the XY plate using M5x16mm BHC
 
 ![fasten the X-Axis Anti-Backlash Nut to the top of the XY plate using M5x16mm BHCS](../img/y_axis_assembly/y_axis_step_10.png){: .shadow}
 
-
 !!! warning "Anti-Backlash Preload Tuning"
     Each axis uses anti-backlash[^1] blocks in order to compensate for changes in screw direction during operation. They do this by driving 2 brass TR8x8 lead-screw nuts towards each other to engage both sides of the lead-screw threads.
 
@@ -137,6 +139,7 @@ Fasten the X-Axis Anti-Backlash Nut to the top of the XY plate using M5x16mm BHC
 [^1]: Yes, technically this is a "zero backlash" nut and not an "anti-backlash nut" - but the common term for it is anti-backlash and that's what most people know it as.
 
 ---
+
 ## Y-Axis Motor Mount and Bearing Block
 
 !!! info annotate "Components Required"
@@ -150,6 +153,7 @@ Fasten the X-Axis Anti-Backlash Nut to the top of the XY plate using M5x16mm BHC
      1 x Y-Axis Motor Mount (1)
      1 x Y-Axis Bearing Block (2)
     ```
+
 1. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#y-axis-assembly)!
 2. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#y-axis-assembly)!
 
@@ -206,11 +210,11 @@ Fasten the MGN15 rails to the Y-Axis, screwing M3x10mm SHCS into every second ho
     Spring T-Nuts are used here to mount the rails but are not shown, install these prior to screwing the bolts in.
 
 !!! tip "Aligning the rails"
-    ![](../img/hardware/rail_alignment_tool.png){: .shadow}
+    ![Rail Alignment Tool Render](../img/hardware/rail_alignment_tool.png){: .shadow}
 
     Use the MGN15 guides to position the first rail in the center of the extrusion prior to fastening the screws. Use a DTI running along the edge of the extrusion to fine adjust it into alignment with the extrusion.
 
-    With the first rail aligned, fit the second rail using the MGN15 guides and use a DTI to clock it in to the first rail. Make sure to check both horizontal alignment and vertical alignment and shim if required. 
+    With the first rail aligned, fit the second rail using the MGN15 guides and use a DTI to clock it in to the first rail. Make sure to check both horizontal alignment and vertical alignment and shim if required.
 
 ---
 
@@ -261,15 +265,15 @@ Using an 8 to 6.35mm rigid coupler, attach the 550mm lead-screw to the NEMA23 mo
 
 From the back of the Y-Axis assembly, insert the screw and motor assembly. Be sure to thread it through the Y Anti-Backlash Nut, but do not insert it through the bearing block yet.
 
-![](../img/y_axis_assembly/y_axis_step_19.png){: .shadow}
+![insert the lead screw and motor into the Y-Axis](../img/y_axis_assembly/y_axis_step_19.png){: .shadow}
 
 ---
 
 Before pushing the lead-screw through the bearing block, add a locking collar to the inside bearing face. Leave this loose.
 
-![](../img/y_axis_assembly/y_axis_step_20_1.png){: .shadow}
+![add a locking collar on the lead-screw before pushing it through the bearing block](../img/y_axis_assembly/y_axis_step_20_1.png){: .shadow}
 
-![](../img/y_axis_assembly/y_axis_step_20_2.png){: .shadow}
+![top view of the locking collar added to the lead-screw](../img/y_axis_assembly/y_axis_step_20_2.png){: .shadow}
 
 ---
 
@@ -281,7 +285,7 @@ Fasten the NEMA23 motor to the Y-Axis motor mount using M5x30 SHCS.
 
 Add the last locking collar on the operator side of the bearing block.
 
-![](../img/y_axis_assembly/y_axis_step_22.png){: .shadow}
+![add a locking collar on the lead-screw on the outside of the bearing block](../img/y_axis_assembly/y_axis_step_22.png){: .shadow}
 
 ---
 
@@ -292,27 +296,27 @@ Using your fingers, press each locking collar towards each other - driving them 
 !!! note
     Add some medium-strength threadlock to the set-screw.
 
-![](../img/y_axis_assembly/y_axis_step_23.png){: .shadow}
+![preload the locking collars by squeezing them together](../img/y_axis_assembly/y_axis_step_23.png){: .shadow}
 
 ---
 
 To avoid the Y-Axis endstop getting damaged during the rest of the assembly, it is a good idea to install it later with the rest of the wiring.
 
-![](../img/y_axis_assembly/y_axis_step_23_1.png){: .shadow}
+![install the Y-Axis endstop, but later!](../img/y_axis_assembly/y_axis_step_23_1.png){: .shadow}
 
 ---
 
 ## Y-Axis Drag Chain
 
-
 !!! info annotate "Components Required"
     ```
      6 x M3x6mm FHCS
      3 x M3 Heat-set Insert
-     1 x 10mm x 11mm Cable Chain
+     1 x 10mm x 11mm Drag Chain
      1 x Y Drag Chain Mount (1)
     ```
-1. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#cable-chain-mounts)!
+
+1. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#drag-chain-mounts)!
 
 Insert the M3 heat-set inserts into the Y-Axis Drag Chain Mount.
 
@@ -344,18 +348,16 @@ Fasten the other end link to the XY Drag Chain Transition using M3x6mm FHCS.
 
 ---
 
-
 <!-- TODO do a composite image to replicate the zoom in done in the original manual -->
 
+## Drag Chain Installation Point (Optional)
 
-## Cable Chain Installation Point (Optional)
-
-You may wish to install the rest of the cable chain now to complete the Y-Axis - but it is often easier to thread your X-Axis motor and endstop cables through the loose chain before installing it as it can become quite a tight space to work in later.
+You may wish to install the rest of the drag chain now to complete the Y-Axis - but it is often easier to thread your X-Axis motor and endstop cables through the loose chain before installing it as it can become quite a tight space to work in later.
 
 !!! note
     Remember this chain is for X-Axis cables despite being mentioned now during Y-Axis assembly.
 
-![](../img/y_axis_assembly/y_axis_step_26_3.png){: .shadow}
+![the Y axis drag chain as installed](../img/y_axis_assembly/y_axis_step_26_3.png){: .shadow}
 
 ---
 

--- a/docs/milo/manual/chapters/50_x_axis_assembly.md
+++ b/docs/milo/manual/chapters/50_x_axis_assembly.md
@@ -1,8 +1,9 @@
-# X Axis Assembly
+# X-Axis Assembly
 
-![](../img/x_axis_assembly/x_axis_assembly.png)
+![Assembled X-Axis](../img/x_axis_assembly/x_axis_assembly.png)
 
 ---
+
 ## X-Axis Rails, Bearing Block and Motor Mount
 
 !!! info annotate "Components Required"
@@ -18,6 +19,7 @@
      1 x X-Axis Motor Mount (1)
      1 x X-Axis Bearing Block (2)
     ```
+
 1. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#x-axis-assembly)!
 2. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#x-axis-assembly)!
 
@@ -26,7 +28,7 @@ Fasten the MGN15 500mm rails to the extrusion by screwing M3x10mm SHCS into spri
 ![fasten the MGN15 500mm Rails to the 500mm extrusion screwing M3x10mm SHCS into the spring t-nuts inside the profile](../img/x_axis_assembly/y_axis_step_27.png){: .shadow}
 
 !!! tip annotate "Aligning the Rails"
-    Repeat the alignment procedure described for the Y axis to ensure your rails are aligned to each other and the extrusion. 
+    Repeat the alignment procedure described for the Y axis to ensure your rails are aligned to each other and the extrusion.
 
 ---
 
@@ -65,6 +67,7 @@ Fasten the X-Axis Motor Mount to the 500mm C-beam using M5x12mm BHCS.
      2 x X-Axis Table Support (centres) (2)
      2 x Openbuilds 2040 Extrusion - 500mm
     ```
+
 1. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#x-axis-assembly)!
 2. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#x-axis-assembly)!
 
@@ -86,11 +89,12 @@ Fasten the X-Axis Table Supports to the 2040 extrusions using M5x8mm BHCS and sp
 
 !!! warning
     Double-check the length of M5 bolts you're using. If your bolts are too long you will bottom out the bolt in the extrusion channel and it will not grip the table supports. If your bolts are too short you'll break the printed parts if you over-tighten them.
+
 ---
 
 Slide the table into the carriages on the XY Gantry Plate from the left-hand side, with the machine facing the operator.
 
-![](../img/x_axis_assembly/y_axis_step_34_1.png){: .shadow}
+![slide the table onto the carriages on the XY gantry plate](../img/x_axis_assembly/y_axis_step_34_1.png){: .shadow}
 
 ---
 
@@ -117,7 +121,7 @@ Remember to use medium-strength threadlock on the grub-screws in the couplers!
 
 Insert the lead-screw through the X-Axis Motor Mount, threading it through the X-Axis Bearing Block until it extends from the other end of the table.
 
-![](../img/x_axis_assembly/y_axis_step_35.png){: .shadow}
+![insert the lead-screw through the X-Axis motor mount](../img/x_axis_assembly/y_axis_step_35.png){: .shadow}
 
 ---
 
@@ -135,7 +139,7 @@ Fasten the motor to the X-Axis Motor Mount using M5x20mm SHCS.
 
 Install a locking collar onto the lead-screw, leaving it loose.
 
-![](../img/x_axis_assembly/y_axis_step_38_2.png){: .shadow}
+![install a locking collar onto the lead-screw](../img/x_axis_assembly/y_axis_step_38_2.png){: .shadow}
 
 ---
 
@@ -152,7 +156,7 @@ Using your fingers, press each locking collar towards each other - driving them 
 !!! note
     Add some medium-strength threadlock to the grub-screws.
 
-![](../img/x_axis_assembly/y_axis_step_38_2.png){: .shadow}
+![preload the locking collars by pressing them towards each other](../img/x_axis_assembly/y_axis_step_38_2.png){: .shadow}
 
 ---
 
@@ -169,15 +173,15 @@ Attach the drag chain ends to the XY Drag Chain Transition and X Motor Mount usi
 !!! note "Drag chain orientation"
     Drag chains have 2 different sides - a fixed side and a free side. For this setup, the fixed side is connected to the XY Drag Chain Transition. The free side attaches itself to the X Motor Mount.
 
-![](../img/x_axis_assembly/y_axis_step_39.png){: .shadow}
+![attach the drag chain ends](../img/x_axis_assembly/y_axis_step_39.png){: .shadow}
 
 ---
 
-## Cable Chain Installation Point (Optional)
+## Drag Chain Installation Point (Optional)
 
-You may wish to install the rest of the cable chain now to complete the X-Axis, however it is often easier to thread your X-Axis motor and endstop cables through the loose chain before installing it - otherwise it can become quite a tight space to work in later.
+You may wish to install the rest of the drag chain now to complete the X-Axis, however it is often easier to thread your X-Axis motor and endstop cables through the loose chain before installing it - otherwise it can become quite a tight space to work in later.
 
-![](../img/x_axis_assembly/y_axis_step_40.png){: .shadow}
+![optionally, install the drag chain in the ends](../img/x_axis_assembly/y_axis_step_40.png){: .shadow}
 
 ---
 
@@ -185,7 +189,7 @@ You may wish to install the rest of the cable chain now to complete the X-Axis, 
 
 To avoid the endstop getting damaged during the rest of the assembly, its a good idea not to install it at this point, but rather install it later with the rest of the wiring.
 
-![](../img/x_axis_assembly/y_axis_step_41.png){: .shadow}
+![optionally, install the x-axis endstop now](../img/x_axis_assembly/y_axis_step_41.png){: .shadow}
 
 ---
 
@@ -206,19 +210,19 @@ To avoid the endstop getting damaged during the rest of the assembly, its a good
 
 Insert the M3 heat-set inserts into the handwheel. These inserts are used to hold the wheel onto the lead screw.
 
-![](../img/x_axis_assembly/x_axis_handwheel_1.png){: .shadow}
+![insert the M3 heat-set inserts into the handwheel](../img/x_axis_assembly/x_axis_handwheel_1.png){: .shadow}
 
 ---
 
 Insert the M5 heat-set insert into the handwheel. Attach the handwheel handle using an M5x25 SHCS bolt.
 
-![](../img/x_axis_assembly/x_axis_handwheel_2.png){: .shadow}
+![insert the M5 heat-set insert into the handwheel](../img/x_axis_assembly/x_axis_handwheel_2.png){: .shadow}
 
 ---
 
-Place the handle onto the X and Y axis and secure using two M3x10 SHCS or two M3 grub screws.
+Place the handle onto the X and Y axis Lead-screws and secure using two M3x10 SHCS or two M3 grub screws.
 
-![](../img/x_axis_assembly/x_axis_handwheel_3.png){: .shadow}
+![place the handle onto the X and Y axis lead-screws](../img/x_axis_assembly/x_axis_handwheel_3.png){: .shadow}
 
 !!! tip
     Repeat these handwheel steps for the Y axis handwheel!

--- a/docs/milo/manual/chapters/60_z_axis_assembly.md
+++ b/docs/milo/manual/chapters/60_z_axis_assembly.md
@@ -228,7 +228,7 @@ Install the MGN15 250mm rails with only the lower carriages installed onto the `
     You can use the rail alignment guides to stop the lower carriages from falling off the vertical rail!
 
 !!! tip annotate "Aligning the Rails"
-    Repeat the alignment procedure described for the Y axis to ensure your rails are aligned to each other and the extrusion. 
+    Repeat the alignment procedure described for the Y axis to ensure your rails are aligned to each other and the extrusion.
 
 ---
 
@@ -371,8 +371,8 @@ And at the top using M5x12mm BHCS.
     1 x Z Drag-Chain Mount   (1)
     1 x Z Cable Redirect Hook (2)
     ```
-1. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#cable-chain-mounts)!
-2. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#cable-chain-mounts)!
+1. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#drag-chain-mounts)!
+2. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#drag-chain-mounts)!
 
 Install the M3 heat-set inserts into the Z Drag-Chain Mount.
 
@@ -507,7 +507,7 @@ If you wish at this point, you can glue in your Millennium Machines Logo.
      1 x Z Drag-Chain Mount B (1)
      1 x Drag Chain
     ```
-1. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#cable-chain-mounts)!
+1. :material-printer-3d-nozzle-heat-outline: Print this part using the [recommended settings](../../printing/print_guide.md#drag-chain-mounts)!
 
 Install the M3 Heat-set inserts into the Z Drag-Chain Mount B.
 

--- a/docs/milo/printing/print_guide.md
+++ b/docs/milo/printing/print_guide.md
@@ -93,7 +93,7 @@ To make some features printable without support, some features are printed with 
 | [65mm Spindle Mount Part B      ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Spindle%20Mount/%5Ba%5D%20Spindle%20Mount%2080mm%20Part%20A%20x1.stl)        | 40%  | 2.4mm | ABS/ASA | 1 | :material-close: No |
 | [Logo Insert                    ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Spindle%20Mount/Logo%20Insert%20x1.stl)                                      | 40%  | 2.4mm | ABS/ASA | 1 | :material-close: No |
 
-## Cable Chain Mounts
+## Drag Chain Mounts
 | **Name** | **Infill** | **Min. Wall Thickness** | **Material** | **Qty** | **Accent Color** |
 |----------|------------|-------------------------|--------------|--------:|----------------------|
 | [XY Drag Chain Transition       ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Cable%20Chain%20Mounts/%5Ba%5D%20XY%20Drag%20Chain%20Transition%20x1.stl)    | 40%  | 1.2mm   | ABS/ASA | 1 | :material-check: Yes |
@@ -101,7 +101,7 @@ To make some features printable without support, some features are printed with 
 | [Z Drag Chain Mount A           ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Cable%20Chain%20Mounts/%5Ba%5D%20Z%20Drag%20Chain%20Mount%20A%20x1.stl)      | 40%  | 1.2mm   | ABS/ASA | 1 | :material-check: Yes |
 | [Z Drag Chain Mount B           ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Cable%20Chain%20Mounts/%5Ba%5D%20Z%20Drag%20Chain%20Mount%20B%20x1.stl)      | 40%  | 1.2mm   | ABS/ASA | 1 | :material-check: Yes |
 | [Z Cable Redirect Hook          ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Cable%20Chain%20Mounts/%5Ba%5D%20Z%20Cable%20Redirect%20Hook%20x1.stl)       | 40%  | 1.2mm   | ABS/ASA | 1 | :material-check: Yes |
-| [Z Axis Cable Chain Backer      ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Cable%20Chain%20Mounts/%5Ba%7D%20Z%20Axis%20Cable%20Chain%20Backer%20x1.stl) | 40%  | 1.2mm   | ABS/ASA | 1 | :material-check: Yes |
+| [Z Axis Drag Chain Backer      ](https://github.com/MillenniumMachines/Milo-v1.5/tree/main/STL%20Files/Minimill%20Main/Cable%20Chain%20Mounts/%5Ba%7D%20Z%20Axis%20Cable%20Chain%20Backer%20x1.stl) | 40%  | 1.2mm   | ABS/ASA | 1 | :material-check: Yes |
 
 ## Electronics Table
 | **Name** | **Infill** | **Min. Wall Thickness** | **Material** | **Qty** | **Accent Color** | **Note** |


### PR DESCRIPTION
We used cable chain / drag chain interchangeably even within 2 paragraphs of each other. We now use just "Drag Chain" or similar. This also fixes 