### PR TITLE
Mos extra docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,3 +36,4 @@ Docs coming soon! For now, please use the PDF manual.
 - [Introduction](./millennium-os/manual/chapters/10_introduction.md)
 - [Installation](./millennium-os/manual/chapters/20_installation.md)
 - [Usage](./millennium-os/manual/chapters/30_usage.md)
+- [G-Codes](./millennium-os/manual/chapters/40_gcodes.md)

--- a/docs/millennium-os/index.md
+++ b/docs/millennium-os/index.md
@@ -8,3 +8,4 @@ MillenniumOS provides post-processors for common CAD/CAM packages (currently Fus
 - [Introduction](./manual/chapters/10_introduction.md)
 - [Installation](./manual/chapters/20_installation.md)
 - [Usage](./manual/chapters/30_usage.md)
+- [G-Codes](./manual/chapters/40_gcodes.md)

--- a/docs/millennium-os/manual/chapters/10_introduction.md
+++ b/docs/millennium-os/manual/chapters/10_introduction.md
@@ -6,7 +6,10 @@ The "OS" stands for "Operations System" rather than "Operat*ing* System" - becau
 
 The aim of MillenniumOS is to build on the usability and configurability of RRF, adding functionality required for efficient and repeatable machining that you would otherwise have to write yourself if using vanilla RRF.
 
-We hope that MillenniumOS makes Millennium Machines the simplest route for novice machinists to make their first cuts confidently and safely - that said, MillenniumOS *is not entirely specific to our machines* - it should be possible to use MillenniumOS out-of-the-box on any 3-axis, moving-table CNC machine with a single spindle that runs RRF **3.5+**, as long as the axis minima and maxima are in the same directions.
+We hope that MillenniumOS makes Millennium Machines the simplest route for novice machinists to make their first cuts confidently and safely - that said, MillenniumOS *is not specific to our machines* - it should be possible to use MillenniumOS out-of-the-box on any 3-axis, moving-table CNC machine with a single spindle that runs RRF **3.5+**, as long as the axis minima and maxima are in the same directions
+
+!!! tip
+    On machines that do not match the design or layout above, it should still be possible to use MillenniumOS with minimal changes - but corner and surface names may be in the wrong order, since these are specific to the directions of the axes on the machine. These can be changed with minimal impact.
 
 MillenniumOS is multiple things:
 

--- a/docs/millennium-os/manual/chapters/20_installation.md
+++ b/docs/millennium-os/manual/chapters/20_installation.md
@@ -26,7 +26,7 @@ Once the Zip file has been downloaded, you can simply upload it to DWC using the
 
 ---
 
-Each of the files from the Zip will be uploaded individually. You can see the list of files being uploaded and there will be a notification when the whole Zip file has been uploaded. Once the upload is complete, click **"Close""*.
+Each of the files from the Zip will be uploaded individually. You can see the list of files being uploaded and there will be a notification when the whole Zip file has been uploaded. Once the upload is complete, click **"Close"**.
 
 ![Uploaded file list in DWC](../img/mos_install_step_2.png){: .shadow-dark }
 
@@ -262,9 +262,9 @@ You can find this directory by going to **Macro -> Macros** from the menu bar, a
 Once the file is placed there, it will be selectable as the Processor under every *Job* instance from the *Path* workbench.
 
 !!! note
-    The FreeCAD post-processor is designed to work with the [Realthunder branch](https://github.com/realthunder/FreeCAD) (otherwise known as the Link branch) of FreeCAD. It may or may not work with stock FreeCAD, depending on which Python version is bundled (the post-processor needs at least 3.10).
+    The FreeCAD post-processor is designed to work with the [Realthunder branch](https://github.com/realthunder/FreeCAD) (otherwise known as the Link branch) of FreeCAD. It may or may not work with stock FreeCAD, depending on which Python version is bundled (the post-processor needs at least 3.11).
 
-    You should think about switching to the Realthunder branch of FreeCAD if you haven't already - it is more stable with complex designs thanks to attempting to fix the [Topological Naming Problem](https://github.com/realthunder/FreeCAD_assembly3/wiki/Topological-Naming).
+    You should consider switching to the Realthunder branch of FreeCAD if you haven't already - it is more stable with complex designs thanks to attempting to fix the [Topological Naming Problem](https://github.com/realthunder/FreeCAD_assembly3/wiki/Topological-Naming).
 ---
 
 You're now ready to add some toolpaths and then run the post to generate MillenniumOS flavoured output gcode. These steps are not MillenniumOS specific, and are therefore outside of the scope of this documentation.

--- a/docs/millennium-os/manual/chapters/30_usage.md
+++ b/docs/millennium-os/manual/chapters/30_usage.md
@@ -246,7 +246,14 @@ flowchart TB
 
 ### Circular Bore
 
-Circular bore sets a WCS origin in X and Y axes to the center of a circular bore (hole) in a work-piece. This is usually used to zero off a hole in a partly-machined work-piece, or off a similar feature in a fixture plate.
+Circular bore finds the X and Y co-ordinates of the centre of a circular bore (hole) in a work-piece by moving downwards into the bore from an operator-chosen approximate centre-point, then probing outwards in 3 directions to the approximate radius of the bore, plus an overtravel amount. You will be asked to enter the following information:
+
+* **Bore Diameter** - Approximate diameter of the bore, used to calculate target probe points.
+* **Overtravel** - Added to the bore diameter, accounting for any innaccuracy in the operator-chosen centre-point of the bore. If the probe is not activated after travelling `radius + overtravel` from the operator-chosen centre-point of the bore then the probe cycle will return an error.
+* **Approximate Centre-Point** - You will be prompted to jog the probe or datum tool over the approximate centre-point of the bore.
+* **Probe Depth** - The depth from the operator-chosen centre-point to descend to, before moving outwards to detect the bore circumference.
+
+Circular bore sets a WCS origin in X and Y axes to the centre of the bore. This is usually used to zero off a hole in a partly-machined work-piece, or off a similar feature in a fixture plate.
 
 ```mermaid
 flowchart TB
@@ -262,7 +269,7 @@ flowchart TB
     subgraph P3[Probe 3]
         6(Probe outwards to bore radius at 240 degrees)
     end
-    7(Move to bore center X,Y) -->
+    7(Move to bore centre X,Y) -->
     8(Move up to starting height)
 
     1 --> P1 --> P2 --> P3 --> 7
@@ -270,7 +277,17 @@ flowchart TB
 
 ### Circular Boss
 
-Circular boss sets a WCS origin in X and Y axes to the center of a circular boss (protruding feature) in a work-piece. This can be used to zero to the center of a circular work-piece, or a previously-machined circular feature that protrudes from the work-piece surface.
+Circular boss finds the X and Y co-ordinates of the centre of a circular boss (protruding feature) on a work-piece by moving outside the expected diameter of the boss by the clearance distance, then descending to a probing depth from the current Z position and probing back towards the approximate centre of the boss until the probe is triggered.
+
+It then backs off, lifts up above the top surface of the boss and repeats this cycle in another 2 locations around the boss to generate a centre point. You will be asked to enter the following information:
+
+* **Boss Diameter** - Approximate diameter of the boss, used to calculate start and target probe points.
+* **Clearance** - Added to the boss radius, this is how far the probe cycle will move outside of the expected surface of the boss before probing back towards the surface.
+* **Overtravel** - Subtracted from the boss radius, accounting for any innaccuracy in the operator-chosen centre-point of the boss. If the probe is not activated after travelling `clearance + overtravel` towards the operator-chosen centre-point of the boss from the starting location, then the probe cycle will return an error.
+* **Approximate Centre-Point** - You will be prompted to jog the probe or datum tool over the approximate centre-point of the boss.
+* **Probe Depth** - The depth from the operator-chosen centre-point to descend to, after moving outwards to each boss probe location, before probing back towards the centre-point.
+
+Circular boss sets a WCS origin in X and Y axes to the centre of the boss. This can be used to zero to the centre of a circular work-piece, or a previously-machined circular feature that protrudes from the work-piece surface.
 
 ```mermaid
 flowchart TB
@@ -292,14 +309,14 @@ flowchart TB
         11(Probe inwards to boss radius at 240 degrees)
     end
     12(Move up to starting height) -->
-    13(Move to boss center X,Y)
+    13(Move to boss centre X,Y)
 
     P1 --> 4 --> P2 --> 8 --> P3 --> 12
 ```
 
 ### Rectangle Pocket
 
-Rectangle pocket sets a WCS origin in X and Y axes to the center of a rectangular pocket (subtractive feature) in a work-piece. This is likely to be a previously machined feature. This can be used on pockets that have corner radiuses in X and Y, as long as the clearance distance is higher than the corner radius (so the probe is only triggering against 'flat' surfaces).
+Rectangle pocket sets a WCS origin in X and Y axes to the centre of a rectangular pocket (subtractive feature) in a work-piece. This is likely to be a previously machined feature. This can be used on pockets that have corner radiuses in X and Y, as long as the clearance distance is higher than the corner radius (so the probe is only triggering against 'flat' surfaces).
 
 ```mermaid
 flowchart TB
@@ -316,7 +333,7 @@ flowchart TB
         8(Probe inwards of back left corner) -->
         9(Probe inwards of back right corner)
     end
-    10(Move to rectangle pocket center X,Y) -->
+    10(Move to rectangle pocket centre X,Y) -->
     11(Move up to starting height)
 
     1 --> A1 --> A2 --> 10
@@ -324,7 +341,7 @@ flowchart TB
 
 ### Rectangle Block
 
-Rectangle block sets a WCS origin in X and Y axes to the center of a rectangular block (protruding feature or a rectangular work-piece itself). This probing cycle is additionally useful for measurement, as it can be used to calibrate touch probes or accurately measure the dimensions of a work-piece.
+Rectangle block sets a WCS origin in X and Y axes to the centre of a rectangular block (protruding feature or a rectangular work-piece itself). This probing cycle is additionally useful for measurement, as it can be used to calibrate touch probes or accurately measure the dimensions of a work-piece.
 
 ```mermaid
 flowchart TB
@@ -353,7 +370,7 @@ flowchart TB
         16(Probe inwards of rear right corner) -->
         17(Move up to starting height)
     end
-    18(Move to rectangle block center X,Y)
+    18(Move to rectangle block centre X,Y)
 
     2 --> A1 --> 6
     7 --> A2 --> 10 --> A3 --> 14 --> A4 --> 18

--- a/docs/millennium-os/manual/chapters/30_usage.md
+++ b/docs/millennium-os/manual/chapters/30_usage.md
@@ -109,11 +109,19 @@ If you are running a job file and the mainboard reboots unexpectedly, you should
 
 If you see these errors often, then you can enable `Low Memory Mode` in the post-processor, if available, and this will help to reduce memory usage during file processing by turning any arc moves into linear moves so that RRF does not have to process these internally.
 
-```
+```output
 Last reset 00:02:25 ago, cause: software
 Last software reset at 2024-03-22 16:55, reason: OutOfMemory, Gcodes spinning, available RAM 13468, slot 0
 ...
 ```
+
+### Combining Multiple Operations
+
+One of the most painful Fusion360 limitations when you don't have a subscription is not being able to export a single file that uses multiple tools.
+
+You can get around this by exporting each set of operations using the same tool individually, and then combine them after using a text editor or similar. To make this process easier, you should turn off **"Output job setup commands"** for all but the first exported file, which will skip any homing or probing cycles that would occur at the start of each file.
+
+Probing will still be triggered before switching into a new WCS, and the tools will still be outputted before they are needed, but the machine will not re-home or run any probing cycles at the start of each new set of operations.
 
 ### FreeCAD
 
@@ -191,9 +199,18 @@ During the execution of a job, and with default post-processor settings, you wil
 
 For advanced usage, you can switch the **"WCS Origin Probing Mode"** to **"None"**, and this will not automatically trigger a probing cycle of each WCS, either at the beginning of the job or just prior to switching into the WCS. You will need to either set the WCS origin manually or Use the features of your CAM or post-processor to inject probing cycle calls where necessary.
 
-When a probe cycle is triggered, you will see the following dialog box, which allows you to select the probing cycle that you would like to use to zero the WCS in question.
+When a probe cycle is triggered by the post-processor, you will see the following dialog box, which allows you to select the probing cycle that you would like to use to zero the WCS in question.
 
 ![MillenniumOS probe cycle selection dialog box](../img/mos_usage_step_5.png){: .shadow-dark }
+
+---
+
+!!! note
+    You can also run individual probe cycles directly from the **"Macros"** menu of DWC when a job is not running. These macros do **NOT** set the origin of a WCS - this is only done by the `G6600` macro, which can be run manually using the **"Probe Workpiece"** entry in the **"Macros"** list.
+
+    If you want to set the origin of a WCS, use the **"Probe Workpiece"** macro and select the cycle you want to use from there.
+
+    When you run the probing cycle macros directly, the information that these generate is saved to global variables that can be used by custom code, or to manually set the origin. These details can be viewed by running `M7600` in the console. The variable names are shortened to save memory so you will need to refer to their descriptions in `mos-vars.g` to understand what information these variables contain.
 
 <!--
     NOTE: Headings in this section at depth 3 create anchors that are linked to by
@@ -246,7 +263,9 @@ flowchart TB
 
 ### Circular Bore
 
-Circular bore finds the X and Y co-ordinates of the centre of a circular bore (hole) in a work-piece by moving downwards into the bore from an operator-chosen approximate centre-point, then probing outwards in 3 directions to the approximate radius of the bore, plus an overtravel amount. You will be asked to enter the following information:
+Circular bore finds the X and Y co-ordinates of the centre of a circular bore (hole) in a work-piece by moving downwards into the bore from an operator-chosen approximate centre-point, then probing outwards in 3 directions to the approximate radius of the bore, plus an overtravel amount. After all of the points have been probed, the probe will move to the calculated centre of the bore and back up to the starting position in Z.
+
+You will be asked to enter the following information:
 
 * **Bore Diameter** - Approximate diameter of the bore, used to calculate target probe points.
 * **Overtravel** - Added to the bore diameter, accounting for any innaccuracy in the operator-chosen centre-point of the bore. If the probe is not activated after travelling `radius + overtravel` from the operator-chosen centre-point of the bore then the probe cycle will return an error.
@@ -279,7 +298,9 @@ flowchart TB
 
 Circular boss finds the X and Y co-ordinates of the centre of a circular boss (protruding feature) on a work-piece by moving outside the expected diameter of the boss by the clearance distance, then descending to a probing depth from the current Z position and probing back towards the approximate centre of the boss until the probe is triggered.
 
-It then backs off, lifts up above the top surface of the boss and repeats this cycle in another 2 locations around the boss to generate a centre point. You will be asked to enter the following information:
+It then backs off, lifts up above the top surface of the boss and repeats this cycle in another 2 locations around the boss to generate a centre point. The probe will then be moved back to the starting Z position and over the centre-point of the boss.
+
+You will be asked to enter the following information:
 
 * **Boss Diameter** - Approximate diameter of the boss, used to calculate start and target probe points.
 * **Clearance** - Added to the boss radius, this is how far the probe cycle will move outside of the expected surface of the boss before probing back towards the surface.
@@ -316,7 +337,18 @@ flowchart TB
 
 ### Rectangle Pocket
 
-Rectangle pocket sets a WCS origin in X and Y axes to the centre of a rectangular pocket (subtractive feature) in a work-piece. This is likely to be a previously machined feature. This can be used on pockets that have corner radiuses in X and Y, as long as the clearance distance is higher than the corner radius (so the probe is only triggering against 'flat' surfaces).
+Rectangle Pocket finds the X and Y co-ordinates of the centre of a rectangular pocket (recessed feature) on a workpiece by descending into the pocket from an operator-chosen approximate centre-point, and then probing twice along each internal surface of the pocket, at the clearance distance inwards and inside of each expected corner.
+
+You will be asked to enter the following information:
+
+* **Width of Pocket** - The approximate width of the pocket, measured along the X axis. The surfaces along the X axis would be facing directly towards or away from you if you were standing at the front of the machine.
+* **Length of Pocket** - The approximate length of the pocket, measured along the Y axis. The surfaces along the Y axis would be to the left and right of you, if you were standing at the front of the machine.
+* **Clearance** - The distance inwards from each corner and inside of each surface that will be used to calculate our starting points to probe. For example, when probing near the front left corner, our starting point would be the approximate location of the corner in X and Y (based on the operator-chosen approximate centre-point of the pocket, width and length) plus the clearance distance, in each (i.e. moving away, inwards, from the expected corner position).
+* **Overtravel** - The distance 'past' each expected surface to set the probe target location, which accounts for any inaccuracy in the operator-chosen centre-point of the pocket, or rotation of the pocket itself.
+* **Approximate Centre-Point** - You will be prompted to jog the probe or datum tool over the approximate centre-point of the pocket.
+* **Probe Depth** - The depth from the operator-chosen centre-point to descend to, before probing the inner surfaces of the pocket.
+
+Rectangle pocket sets a WCS origin in X and Y axes to the centre of the pocket, which is likely to be a previously machined feature. This can be used on pockets that have corner radiuses in X and Y, as long as the clearance distance is higher than the corner radius (so the probe is only triggering against 'flat' surfaces).
 
 ```mermaid
 flowchart TB
@@ -341,7 +373,20 @@ flowchart TB
 
 ### Rectangle Block
 
-Rectangle block sets a WCS origin in X and Y axes to the centre of a rectangular block (protruding feature or a rectangular work-piece itself). This probing cycle is additionally useful for measurement, as it can be used to calibrate touch probes or accurately measure the dimensions of a work-piece.
+Rectangle Block finds the X and Y co-ordinates of the centre of a rectangular block (the work-piece itself, or a rectangular protruding feature) by moving outside of the block from an operator-chosen approximate centre-point, descending to a probing depth and then probing twice along each surface of the block, at the clearance distance inwards and outside of each expected corner.
+
+The probe will be lifted back to the starting Z height after the first X surface has been probed, allowing it to move across the block to the second surface. The probe will stay at the probe height to move across to the first Y surface, and then will return to the starting Z height to move to the second Y surface. After the probing cycle is complete, the probe will be lifted back to the starting Z height and moved above the centre of the block.
+
+You will be asked to enter the following information:
+
+* **Width of Block** - The approximate width of the block, measured along the X axis. The surfaces along the X axis would be facing directly towards or away from you if you were standing at the front of the machine.
+* **Length of Block** - The approximate length of the block, measured along the Y axis. The surfaces along the Y axis would be to the left and right of you, if you were standing at the front of the machine.
+* **Clearance** - The distance inwards from each corner and outside of each surface that will be used to calculate our starting points to probe. For example, when probing near the front left corner on the X axis, our starting point would be the approximate location of the corner in X and Y (based on the operator-chosen approximate centre-point of the block, width and length) plus the clearance distance in Y, and minus the clearance distance in X (i.e. outside the surface and inwards from the expected corner position).
+* **Overtravel** - The distance 'past' each expected surface to set the probe target location, which accounts for any inaccuracy in the operator-chosen centre-point of the block, or rotation of the block itself.
+* **Approximate Centre-Point** - You will be prompted to jog the probe or datum tool over the approximate centre-point of the block.
+* **Probe Depth** - The depth from the operator-chosen centre-point to descend to, before probing the inner surfaces of the block.
+
+Rectangle block sets a WCS origin in X and Y axes to the centre of the block (protruding feature or a rectangular work-piece itself). This probing cycle is additionally useful for measurement, as it can be used to calibrate touch probes or accurately measure the dimensions of a work-piece, as well as identifying its rotation from the machine axes.
 
 ```mermaid
 flowchart TB
@@ -378,12 +423,35 @@ flowchart TB
 
 ### Outside Corner
 
+Outside corner finds the X and Y co-ordinates of the corner of a rectangular work-piece by probing along the 2 edges that form the corner.
+
+It has 2 modes - **Quick** or `Q1`, which takes a single probe point on each surface, or **Full** (`Q0` or unset) which takes 2 probe points along each surface forming the corner.
+
+**Quick** mode is useful when you know the work-piece is square and properly aligned with the axes of the machine. The corner location is identified by the X co-ordinate when probing on the X surface, and the Y co-ordinate when probing on the Y surface.
+
+**Full** mode is useful when you are unsure that the work-piece is square or properly aligned with the axes of the machine. The corner location is identified by taking 2 measurements along each surface, drawing a line through the points on each axis and then calculating where those lines cross. This allows us to calculate the angle of the corner, and if it is square we can also calculate the rotation of the work-piece in relation to the machine axes.
+
+!!! tip
+    Calculating the rotation of the work-piece gives us the information required to compensate for this rotation using RRF's `G68` code. This is not currently implemented but is planned for a later release of MillenniumOS.
+
+    The rotation value will be printed to the console after running this probe cycle, and can be viewed using the `M7600` command before running another probe cycle.
+
+For **Full** mode, you will be asked to enter the following information:
+
+* **Length of X Corner Surface** - The approximate length of the surface, measured along the X axis. The surface along the X axis would be facing directly towards or away from you if you were standing at the front of the machine.
+* **Length of Y Corner Surface** - The approximate length of the surface, measured along the Y axis. The surface along the Y axis would be to the left and right of you, if you were standing at the front of the machine.
+
+For both modes, you will be asked to enter the following information:
+
+* **Clearance** - The distance inwards from the corner and outside of each surface that will be used to calculate our starting points to probe. For example, when probing near the front left corner on the X axis, our starting point would be the approximate location of the corner in X and Y (based on the operator-chosen approximate starting-point above the corner) plus the clearance distance in Y, and minus the clearance distance in X (i.e. outside the surface and inwards from the expected corner position).
+* **Overtravel** - The distance 'past' each expected surface to set the probe target location, which accounts for any inaccuracy in the operator-chosen centre-point of the block, or rotation of the block itself.
+* **Approximate Starting Point** - You will be prompted to jog the probe or datum tool over the corner.
+* **Corner to Probe** - The corner that the probe is currently over, allowing us to calculate the correct directions to move in.
+* **Probe Depth** - The depth from the operator-chosen starting point to descend to, before probing the surfaces that form the corner.
+
+After probing both surfaces, the probe will be moved back up to the starting Z height and then over the corner.
+
 Outside corner sets a WCS origin in X and Y axes to the corner of a rectangular work-piece. It is already used by the vise-corner probe cycle, so should only be used in isolation when you need to zero the Z axis somewhere other than the top surface of the work-piece.
-
-!!! note
-    When using Quick mode (`Q1`), Outside Corner cannot calculate the squareness or rotation of the work-piece, so it will not be possible to compensate for a misaligned part.
-
-    The corner of the part is assumed to be at the exact intersection of 2 lines drawn perpendicular to each axis through the probe points. If your work-piece is not square with the axes, or the corner itself is not square, then the calculated location will be inaccurate.
 
 <!-- This is essentially a copy-paste from Vise Corner with the Z probe removed -->
 ```mermaid

--- a/docs/millennium-os/manual/chapters/40_gcodes.md
+++ b/docs/millennium-os/manual/chapters/40_gcodes.md
@@ -79,7 +79,7 @@ Iterates through all configured probes every `D` milliseconds (default 100) chec
 G6600 [Wnn]
 ```
 
-Called by the post-processor to indicate that workpiece should be probed to set WCS origin, if specified with the `W` parameter then this will be the WCS offset that will be zeroed, rather than asking the operator.
+Called by the post-processor to indicate that workpiece should be probed to set WCS origin, if the `W` parameter is set then this will be the WCS offset that will be zeroed, rather than asking the operator.
 
 If the post knows what _type_ of workpiece probe should be executed, it can call the specific probing operation directly (e.g. `G6500`, `G6501` etc) and then set the WCS using `G10`. Calling `G6600` will prompt the operator to select a probing methodology based on their knowledge of the work piece.
 
@@ -87,8 +87,14 @@ If the post knows what _type_ of workpiece probe should be executed, it can call
 
 #### `G6500` - BORE
 
+```gcode
+G6500 [Wnn]
+```
+
 Guided bore probe, prompts the user for approximate diameter, overtravel, approximate center position and probe depth.
 Executes `G6500.1` with the relevant parameters to run the actual probe.
+
+If the `W` parameter is set then this will be the WCS offset that will be zeroed. If no parameter is set then no WCS will be zeroed.
 
 ##### `G6500.1` - BORE - EXECUTE
 
@@ -97,16 +103,28 @@ center point in each of the 3 directions before the probe cycle will error if it
 
 #### `G6501` - BOSS
 
+```gcode
+G6501 [Wnn]
+```
+
 Guided boss probe, prompts the user for approximate diameter, clearance, overtravel, approximate center position and probe depth.
 Executes `G6501.1` with the relevant parameters to run the actual probe.
 
-##### `G501.1` - BOSS - EXECUTE
+If the `W` parameter is set then this will be the WCS offset that will be zeroed. If no parameter is set then no WCS will be zeroed.
+
+##### `G6501.1` - BOSS - EXECUTE
 
 Calculates the center of a boss and its' radius, by running 3 probes inwards towards the operator-chosen center of the bore. The overtravel is subtracted from the radius of the boss to identify the target location of each probe, and the clearance is added to the radius of the boss to identify the starting locations.
 
 #### `G6502` - RECTANGLE POCKET
 
+```gcode
+G6502 [Wnn]
+```
+
 Guided rectangle pocket probe, prompts the user for an approximate width (X), length (Y), overtravel and clearance, an approximate center position and probe depth. Executes `G6502.1` with the relevant parameters to run the actual probe.
+
+If the `W` parameter is set then this will be the WCS offset that will be zeroed. If no parameter is set then no WCS will be zeroed.
 
 ##### `G6502.1` - RECTANGLE POCKET - EXECUTE
 
@@ -115,7 +133,13 @@ Using the provided width, height, clearance and starting location, we probe outw
 
 #### `G6503` - RECTANGLE BLOCK
 
+```gcode
+G6503 [Wnn]
+```
+
 Guided rectangle block probe, prompts the user for an approximate width (X), length (Y), overtravel and clearance, an approximate center position and probe depth. Executes `G6503.1` with the relevant parameters to run the actual probe.
+
+If the `W` parameter is set then this will be the WCS offset that will be zeroed. If no parameter is set then no WCS will be zeroed.
 
 ##### `G6503.1` - RECTANGLE BLOCK - EXECUTE
 
@@ -140,7 +164,13 @@ Not implemented.
 
 #### `G6508` - OUTSIDE CORNER
 
+```gcode
+G6508 [Wnn]
+```
+
 Guided outside corner probe, prompts the user for an approximate width (X) and length (Y) of the 2 surfaces that make up the corner, a clearance and overtravel distance, a probing depth, a starting location and the corner that we want to probe (front left, back right etc). Executes `G6508.1` with the relevant parameters to run the actual probe.
+
+If the `W` parameter is set then this will be the WCS offset that will be zeroed. If no parameter is set then no WCS will be zeroed.
 
 ##### `G6508.1` - OUTSIDE CORNER - EXECUTE
 
@@ -154,7 +184,13 @@ Not implemented.
 
 #### `G6510` - SINGLE SURFACE
 
+```gcode
+G6510 [Wnn]
+```
+
 Guided single surface probe, which prompts the user for a starting location, overtravel distance, which surface to probe, a maximum probing distance and for X and Y surfaces, a probing depth below the starting location. Can be used to probe the Z height of a workpiece, or a single surface on X or Y if the operator knows these are aligned with the machine axes. This macro only probes a single point so cannot calculate surface angles.
+
+If the `W` parameter is set then this will be the WCS offset that will be zeroed. If no parameter is set then no WCS will be zeroed.
 
 ##### `G6510.1` - SINGLE SURFACE - EXECUTE
 
@@ -168,7 +204,13 @@ Probes the touch probe reference surface in Z, and sets the touch probe activati
 
 #### `G6520` - VISE CORNER
 
+```gcode
+G6520 [Wnn]
+```
+
 Guided probing macro that combines OUTSIDE CORNER and SINGLE SURFACE (Z) macros to zero all 3 axes of a WCS in a single probing operation. This macro prompts the user for the required parameters for the OUTSIDE CORNER macro, as well as a starting location. It calls the macros in sequence, probing the Z surface first before moving outwards and probing each X and Y surface that forms the corner.
+
+If the `W` parameter is set then this will be the WCS offset that will be zeroed. If no parameter is set then no WCS will be zeroed.
 
 ##### `G6520.1` - VISE CORNER - EXECUTE
 
@@ -180,13 +222,25 @@ Executes a Vise Corner probe using the parameters gathered by the operator. Runs
 
 ### `M4000` - DEFINE TOOL
 
-We need to store additional details about tools that RRF is not currently able to accommodate natively - this includes tool radius and deflection values (for probes). `M4000` stores these custom values in a global vector that allows us to use them, while configuring RRF with the relevant tool details using `M563`.
+```gcode
+M4000 Pnn Rnn S"..." [Xnn] [Ynn]
+```
+
+We need to store additional details about tools that RRF is not currently able to accommodate natively - this includes tool radius (`R`) and deflection values for probes (`X` and `Y`). Tool index is set using `P` and description is set using `S".."`. M4000` stores these custom values that allows us to use them, while configuring RRF with the relevant tool details using `M563`.
 
 ### `M4001` - FORGET TOOL
 
-Resets our custom tool table and RRF's tool table at the given index.
+```gcode
+M4001 Pnn
+```
+
+Remove the tool at index `Pnn`.
 
 ### `T<N>` - EXECUTE TOOL CHANGE
+
+```gcode
+Tnn
+```
 
 This macro is built in to RRF, using the `t{free,pre,post}.g` files. If the target tool number is specified, then these files are executed in order. The operator is prompted to change to the correct tool and if this tool is a probe tool, will be asked to verify that the tool is connected by triggering it manually before proceeding.
 
@@ -198,13 +252,23 @@ This macro is built in to RRF, using the `t{free,pre,post}.g` files. If the targ
 
 #### `M3.9` - START SPINDLE AND WAIT
 
+```gcode
+M3.9 [Snnnnn] [Pnn] [Dnnn]
+```
+
 This macro calls RRF's underlying `M3` command to start the spindle, but waits after starting the spindle for it to accelerate based on a previously recorded acceleration value. This value will be reduced based on the rpm-change of the spindle so if it is only accelerating to 50% of its maximum speed then `M3.9` will only wait 50% of the recorded wait value.
+
+Parameters `S` and `P` are passed to the underlying `M3` command if specified, and parameter `D`, specified in seconds, will override the wait time that would've otherwise been calculated.
 
 Additionally, if expert mode is disabled, then this macro will pop up an operator confirmation / warning box when the spindle is going to accelerate from 0 rpm.
 
 #### `M5.9` - STOP SPINDLE AND WAIT
 
-Like the `M3.9` macro above, this macro calls the underlying `M5` macro and if any spindles were activated, waits for them to stop. As above, the deceleration value will be reduced based on the rpm-change of the spindle.
+```gcode
+M5.9 [Dnnn]
+```
+
+Like the `M3.9` macro above, this macro calls the underlying `M5` macro and if any spindles were activated, waits for them to stop. As above, the deceleration value will be reduced based on the rpm-change of the spindle. Specifying the `D` parameter will override the delay time.
 
 ### Variable Spindle Speed Control
 
@@ -212,9 +276,17 @@ Variable Spindle Speed Control (VSSC) constantly adjusts the speed of the spindl
 
 #### `M7000` - ENABLE VSSC
 
-Enable Variable Spindle Speed Control.
+```gcode
+M7000 Pnn Vnn
+```
+
+Enable Variable Spindle Speed Control. The `P` and `V` parameters must be specified, and these control the period (in milliseconds) and variance (in RPM) of the VSSC function.
 
 #### `M7001` - DISABLE VSSC
+
+```gcode
+M7001
+```
 
 Disable Variable Spindle Speed Control
 
@@ -223,5 +295,9 @@ Disable Variable Spindle Speed Control
 ## Debugging
 
 ### `M7600` - OUTPUT ALL KNOWN VARIABLES
+
+```gcode
+M7600 [D1]
+```
 
 Sometimes it is necessary to debug MillenniumOS or RRF, and this macro allows outputting the macro variables that MillenniumOS uses in a manner that can be attached to tickets or discord messages to aid debugging. Call it with the `D1` parameter to enable additional RRF object model output that can help to debug the odder issues.

--- a/docs/millennium-os/manual/chapters/40_gcodes.md
+++ b/docs/millennium-os/manual/chapters/40_gcodes.md
@@ -8,7 +8,7 @@
 ### `G27` - PARK
 
 ```gcode
-G27 [Z0|Z1]
+G27 [Zn]
 ```
 
 Used to park the spindle in a safe location, by default it will move the spindle to the top of the Z axis, trigger an `M5.9` (stop spindle and wait for spin-down), and then move the table to the centre of the X axis and at the front (towards the operator) of the Y axis.
@@ -98,8 +98,16 @@ If the `W` parameter is set then this will be the WCS offset that will be zeroed
 
 ##### `G6500.1` - BORE - EXECUTE
 
+```gcode
+G6500.1 [Wnn] Jnnn Knnn Lnnn Hnnn [Onnn] [R0]
+```
+
 Calculates the center of a bore and its radius, by running 3 probes outwards from the chosen starting position towards the edge of the bore. The overtravel is added to the radius of the bore and this sets the distance moved from the
 center point in each of the 3 directions before the probe cycle will error if it does not trigger.
+
+Parameters `J`, `K` and `L` represent the starting point of the probe in `X`, `Y` and `Z` axes. `H` specifies the approximate diameter of the bore, `O` specifies the overtravel distance and when specified, `R0` suppresses reporting of the probe results.
+
+`W` represents the WCS offset to set the origin on, if passed.
 
 #### `G6501` - BOSS
 
@@ -114,7 +122,16 @@ If the `W` parameter is set then this will be the WCS offset that will be zeroed
 
 ##### `G6501.1` - BOSS - EXECUTE
 
+```gcode
+G6501.1 [Wnn] Jnnn Knnn Lnnn Hnnn [Tnnn] [Onnn] [R0]
+```
+
 Calculates the center of a boss and its' radius, by running 3 probes inwards towards the operator-chosen center of the bore. The overtravel is subtracted from the radius of the boss to identify the target location of each probe, and the clearance is added to the radius of the boss to identify the starting locations.
+
+Parameters `J`, `K` and `L` represent the starting point of the probe in `X`, `Y` and `Z` axes. `H` specifies the approximate diameter of the bore, `O` specifies the overtravel distance, `T` the clearance distance, and when specified, `R0` suppresses reporting of the probe results.
+
+`W` represents the WCS offset to set the origin on, if passed.
+
 
 #### `G6502` - RECTANGLE POCKET
 
@@ -128,8 +145,16 @@ If the `W` parameter is set then this will be the WCS offset that will be zeroed
 
 ##### `G6502.1` - RECTANGLE POCKET - EXECUTE
 
+```gcode
+G6502.1 [Wnn] Jnnn Knnn Lnnn Hnnn Innn [Tnnn] [Onnn] [R0]
+```
+
 Calculates the center of a rectangle pocket, its surface angles, rotation angle (in relation to the X axis) and its dimensions based on 8 different probes.
 Using the provided width, height, clearance and starting location, we probe outwards from inside the expected edges of each surface by the clearance distance. We probe each surface twice to get a surface angle, and validate that the pocket itself is both rectangular and how far it is rotated from the X axis.
+
+Parameters `J`, `K` and `L` represent the starting point of the probe in `X`, `Y` and `Z` axes. `H` and `I` specify the approximate X and Y dimensions of the pocket, `O` specifies the overtravel distance, `T` the clearance distance, and when specified, `R0` suppresses reporting of the probe results.
+
+`W` represents the WCS offset to set the origin on, if passed.
 
 #### `G6503` - RECTANGLE BLOCK
 
@@ -143,8 +168,17 @@ If the `W` parameter is set then this will be the WCS offset that will be zeroed
 
 ##### `G6503.1` - RECTANGLE BLOCK - EXECUTE
 
+```gcode
+G6503.1 [Wnn] Jnnn Knnn Lnnn Hnnn Innn [Tnnn] [Onnn] [R0]
+```
+
 Calculates the center of a rectangle block, its surface angles, rotation angle (in relation to the X axis) and its dimensions based on 8 different probes.
 Using the provided width, height, clearance and starting location, we probe inwards from the expected edges of each surface by the clearance distance. We probe each surface twice to get a surface angle, and validate that the block itself is both rectangular and how far it is rotated from the X axis.
+
+Parameters `J`, `K` and `L` represent the starting point of the probe in `X`, `Y` and `Z` axes. `H` and `I` specify the approximate X and Y dimensions of the block, `O` specifies the overtravel distance, `T` the clearance distance, and when specified, `R0` suppresses reporting of the probe results.
+
+`W` represents the WCS offset to set the origin on, if passed.
+
 
 #### `G6504` - WEB X
 
@@ -174,7 +208,21 @@ If the `W` parameter is set then this will be the WCS offset that will be zeroed
 
 ##### `G6508.1` - OUTSIDE CORNER - EXECUTE
 
+```gcode
+G6508.1 [Wnn] Jnnn Knnn Lnnn Nn [Qn] [Hnnn] [Innn] [Tnnn] [Onnn] [R0]
+```
+
 Calculates the corner position of a square corner on a workpiece in X and Y, as well as calculating the rotation angle and corner angle of the item. Using the provided width, height, clearance, overtravel and starting location, we move outwards along each surface forming the corner, probing at 2 locations on each surface to find their angles, and then calculate where these surfaces intersect at the relevant corner.
+
+Parameters `J`, `K` and `L` represent the starting point of the probe in `X`, `Y` and `Z` axes. `N` indicates the corner number to probe, where the Front Left corner is `0` and the number increases anti-clockwise, with the Back Left corner at `3`.
+
+`Q` identifies the mode - with `Q1`, quick mode is enabled, and no `H` or `I` parameter needs to be passed. Only a single probe point will be taken on each surface of the corner.
+
+With `Q0` (the default), you must also pass `H` and `I` - which specify the approximate X and Y dimensions of the block in millimeters.
+
+In both modes, you can specify `O`, the overtravel distance, and `T`, the clearance distance.
+
+`R0` suppresses reporting of the probe results, and `W` represents the WCS offset to set the origin on, if passed.
 
 #### `G6509` - INSIDE CORNER
 
@@ -194,7 +242,15 @@ If the `W` parameter is set then this will be the WCS offset that will be zeroed
 
 ##### `G6510.1` - SINGLE SURFACE - EXECUTE
 
+```gcode
+G6510.1 [Wnn] Jnnn Knnn Lnnn Hn Innn [Onnn]
+```
+
 Calculates the X, Y or Z co-ordinate of a surface using the provided starting location, surface number, probing distance and depth.
+
+Parameters `J`, `K` and `L` represent the starting point of the probe in `X`, `Y` and `Z` axes. `H` specifies the axis to probe on, starting at 0 for Left, 1 for Right, 2 for Front, 3 for Back, and 4 for Top. `I` specifies the distance to probe towards the surface, and `O` specifies the overtravel distance. `R0` suppresses reporting of the probe results.
+
+`W` represents the WCS offset to set the origin on, if passed.
 
 #### `G6511` - PROBE REFERENCE SURFACE
 
@@ -214,7 +270,23 @@ If the `W` parameter is set then this will be the WCS offset that will be zeroed
 
 ##### `G6520.1` - VISE CORNER - EXECUTE
 
+```gcode
+G6520.1 [Wnn] Jnnn Knnn Lnnn Nn Pnnn [Qn] [Hnnn] [Innn] [Tnnn] [Onnn] [R0]
+```
+
 Executes a Vise Corner probe using the parameters gathered by the operator. Runs a Z probe first, then each corner probe after and sets the WCS origin of all 3 axes at once.
+
+Parameters `J`, `K` and `L` represent the starting point of the probe in `X`, `Y` and `Z` axes. `N` indicates the corner number to probe, where the Front Left corner is `0` and the number increases anti-clockwise, with the Back Left corner at `3`.
+
+`P` indicates the depth to probe the corner surfaces at relative to the probed top surface.
+
+`Q` identifies the mode - with `Q1`, quick mode is enabled, and no `H` or `I` parameter needs to be passed. Only a single probe point will be taken on each surface of the corner.
+
+With `Q0` (the default), you must also pass `H` and `I` - which specify the approximate X and Y dimensions of the block in millimeters.
+
+In both modes, you can specify `O`, the overtravel distance, and `T`, the clearance distance.
+
+`R0` suppresses reporting of the probe results, and `W` represents the WCS offset to set the origin on, if passed.
 
 ---
 

--- a/docs/millennium-os/manual/chapters/40_gcodes.md
+++ b/docs/millennium-os/manual/chapters/40_gcodes.md
@@ -1,0 +1,227 @@
+# Millennium Machines GCode Flavour
+
+!!! warning
+    This document is a work in progress, and will lag behind changes made in MillenniumOS itself. To understand the latest available macros and how these should be called when using them directly, please refer to the code in the [GitHub Repository](https://github.com/MillenniumMachines/MillenniumOS).
+
+## Misc
+
+### `G27` - PARK
+
+```gcode
+G27 [Z0|Z1]
+```
+
+Used to park the spindle in a safe location, by default it will move the spindle to the top of the Z axis, trigger an `M5.9` (stop spindle and wait for spin-down), and then move the table to the centre of the X axis and at the front (towards the operator) of the Y axis.
+
+If called with the `Z1` argument, it will only raise and stop the spindle - the table location will not be changed.
+
+Parking is used widely throughout probing and tool changing to move the spindle to a known starting location which is safe for lateral moves. CNC Firmwares do not always provide a generic park function (including RRF), because this can be machine-specific, so we implement our own.
+
+### `G37` - PROBE TOOL LENGTH
+
+```gcode
+G37
+```
+
+When using multiple milling tools, we must compensate for length differences between the tools. G37 can be used to (re-)calculate the length of the current tool in relation to a reference surface or the previous tool.
+
+`G37` is used widely by CNC mills to probe tool lengths but is not implemented by RRF, so again we implement our own.
+
+### `M3000` - PROMPT OPERATOR WITH CONFIRMABLE DIALOG
+
+```gcode
+M3000 R"Title" S"Message"
+```
+
+Takes both `R` (title) and `S` (message) string parameters, and will display an RRF dialog box. If the machine is currently processing a file and not paused, the dialog box will contain Continue, Pause and Cancel options. If M3000 is called while the machine is not processing a file, only Continue and Cancel options will be shown. This can be used by post-processors to display messages to the operator.
+
+### `M6515` - CHECK CO-ORDINATES ARE WITHIN MACHINE LIMITS
+
+```gcode
+M6515 [Xnnn] [Ynnn] [Znnn]
+```
+
+Takes at least one of X, Y and Z co-ordinates and checks that they are within the axes limits of the machine, otherwise triggers an abort. This is used by other macros to make sure we do not try to move outside of machine limits.
+
+### `G6550` - PROTECTED MOVE
+
+```gcode
+G6550 [Innn|Inull] [Xnnn] [Ynnn] [Znnn]
+```
+
+Takes at least one of X, Y and Z co-ordinates as the target location, and an optional probe ID (I). If the probe ID is given, it will attempt to move to the target location while watching the specified probe for activation due to collision. If a probe ID is not given, this move acts like a G1 move to the target, implementing an unprotected move at the manual probing speed. This macro is called by probing macros to try to avoid damaging any probe due to accidental collisions.
+
+### `G8000` - RUN CONFIGURATION WIZARD
+
+```gcode
+G8000
+```
+
+Triggered when installing MillenniumOS for the first time, and can be called later to reconfigure MillenniumOS. Runs through a modal-driven configuration wizard prompting the user for all of the settings required to run MillenniumOS properly.
+
+### `M8001` - CHECK PROBE STATUS CHANGE
+
+```gcode
+M8001 [Dnnn] [Wnnn]
+```
+
+Iterates through all configured probes every `D` milliseconds (default 100) checking to see if their values have changed. This can be used to identify the right probe via user input when configuring MillenniumOS. Will wait for a maximum of `W` seconds (default 30).
+
+---
+
+## Probing
+
+### META
+
+#### `G6600` - PROBE WORKPIECE
+
+```gcode
+G6600 [Wnn]
+```
+
+Called by the post-processor to indicate that workpiece should be probed to set WCS origin, if specified with the `W` parameter then this will be the WCS offset that will be zeroed, rather than asking the operator.
+
+If the post knows what _type_ of workpiece probe should be executed, it can call the specific probing operation directly (e.g. `G6500`, `G6501` etc) and then set the WCS using `G10`. Calling `G6600` will prompt the operator to select a probing methodology based on their knowledge of the work piece.
+
+### Two Axis
+
+#### `G6500` - BORE
+
+Guided bore probe, prompts the user for approximate diameter, overtravel, approximate center position and probe depth.
+Executes `G6500.1` with the relevant parameters to run the actual probe.
+
+##### `G6500.1` - BORE - EXECUTE
+
+Calculates the center of a bore and its radius, by running 3 probes outwards from the chosen starting position towards the edge of the bore. The overtravel is added to the radius of the bore and this sets the distance moved from the
+center point in each of the 3 directions before the probe cycle will error if it does not trigger.
+
+#### `G6501` - BOSS
+
+Guided boss probe, prompts the user for approximate diameter, clearance, overtravel, approximate center position and probe depth.
+Executes `G6501.1` with the relevant parameters to run the actual probe.
+
+##### `G501.1` - BOSS - EXECUTE
+
+Calculates the center of a boss and its' radius, by running 3 probes inwards towards the operator-chosen center of the bore. The overtravel is subtracted from the radius of the boss to identify the target location of each probe, and the clearance is added to the radius of the boss to identify the starting locations.
+
+#### `G6502` - RECTANGLE POCKET
+
+Guided rectangle pocket probe, prompts the user for an approximate width (X), length (Y), overtravel and clearance, an approximate center position and probe depth. Executes `G6502.1` with the relevant parameters to run the actual probe.
+
+##### `G6502.1` - RECTANGLE POCKET - EXECUTE
+
+Calculates the center of a rectangle pocket, its surface angles, rotation angle (in relation to the X axis) and its dimensions based on 8 different probes.
+Using the provided width, height, clearance and starting location, we probe outwards from inside the expected edges of each surface by the clearance distance. We probe each surface twice to get a surface angle, and validate that the pocket itself is both rectangular and how far it is rotated from the X axis.
+
+#### `G6503` - RECTANGLE BLOCK
+
+Guided rectangle block probe, prompts the user for an approximate width (X), length (Y), overtravel and clearance, an approximate center position and probe depth. Executes `G6503.1` with the relevant parameters to run the actual probe.
+
+##### `G6503.1` - RECTANGLE BLOCK - EXECUTE
+
+Calculates the center of a rectangle block, its surface angles, rotation angle (in relation to the X axis) and its dimensions based on 8 different probes.
+Using the provided width, height, clearance and starting location, we probe inwards from the expected edges of each surface by the clearance distance. We probe each surface twice to get a surface angle, and validate that the block itself is both rectangular and how far it is rotated from the X axis.
+
+#### `G6504` - WEB X
+
+Not implemented.
+
+#### `G6505` - POCKET X
+
+Not implemented.
+
+#### `G6506` - WEB Y
+
+Not implemented.
+
+#### `G6507` - POCKET Y
+
+Not implemented.
+
+#### `G6508` - OUTSIDE CORNER
+
+Guided outside corner probe, prompts the user for an approximate width (X) and length (Y) of the 2 surfaces that make up the corner, a clearance and overtravel distance, a probing depth, a starting location and the corner that we want to probe (front left, back right etc). Executes `G6508.1` with the relevant parameters to run the actual probe.
+
+##### `G6508.1` - OUTSIDE CORNER - EXECUTE
+
+Calculates the corner position of a square corner on a workpiece in X and Y, as well as calculating the rotation angle and corner angle of the item. Using the provided width, height, clearance, overtravel and starting location, we move outwards along each surface forming the corner, probing at 2 locations on each surface to find their angles, and then calculate where these surfaces intersect at the relevant corner.
+
+#### `G6509` - INSIDE CORNER
+
+Not implemented.
+
+### Single Axis
+
+#### `G6510` - SINGLE SURFACE
+
+Guided single surface probe, which prompts the user for a starting location, overtravel distance, which surface to probe, a maximum probing distance and for X and Y surfaces, a probing depth below the starting location. Can be used to probe the Z height of a workpiece, or a single surface on X or Y if the operator knows these are aligned with the machine axes. This macro only probes a single point so cannot calculate surface angles.
+
+##### `G6510.1` - SINGLE SURFACE - EXECUTE
+
+Calculates the X, Y or Z co-ordinate of a surface using the provided starting location, surface number, probing distance and depth.
+
+#### `G6511` - PROBE REFERENCE SURFACE
+
+Probes the touch probe reference surface in Z, and sets the touch probe activation point. Will be called automatically when changing to the touch probe with the feature enabled.
+
+### Three Axis
+
+#### `G6520` - VISE CORNER
+
+Guided probing macro that combines OUTSIDE CORNER and SINGLE SURFACE (Z) macros to zero all 3 axes of a WCS in a single probing operation. This macro prompts the user for the required parameters for the OUTSIDE CORNER macro, as well as a starting location. It calls the macros in sequence, probing the Z surface first before moving outwards and probing each X and Y surface that forms the corner.
+
+##### `G6520.1` - VISE CORNER - EXECUTE
+
+Executes a Vise Corner probe using the parameters gathered by the operator. Runs a Z probe first, then each corner probe after and sets the WCS origin of all 3 axes at once.
+
+---
+
+## Tool Management
+
+### `M4000` - DEFINE TOOL
+
+We need to store additional details about tools that RRF is not currently able to accommodate natively - this includes tool radius and deflection values (for probes). `M4000` stores these custom values in a global vector that allows us to use them, while configuring RRF with the relevant tool details using `M563`.
+
+### `M4001` - FORGET TOOL
+
+Resets our custom tool table and RRF's tool table at the given index.
+
+### `T<N>` - EXECUTE TOOL CHANGE
+
+This macro is built in to RRF, using the `t{free,pre,post}.g` files. If the target tool number is specified, then these files are executed in order. The operator is prompted to change to the correct tool and if this tool is a probe tool, will be asked to verify that the tool is connected by triggering it manually before proceeding.
+
+---
+
+## Spindle Control
+
+### Spindle Start / Stop
+
+#### `M3.9` - START SPINDLE AND WAIT
+
+This macro calls RRF's underlying `M3` command to start the spindle, but waits after starting the spindle for it to accelerate based on a previously recorded acceleration value. This value will be reduced based on the rpm-change of the spindle so if it is only accelerating to 50% of its maximum speed then `M3.9` will only wait 50% of the recorded wait value.
+
+Additionally, if expert mode is disabled, then this macro will pop up an operator confirmation / warning box when the spindle is going to accelerate from 0 rpm.
+
+#### `M5.9` - STOP SPINDLE AND WAIT
+
+Like the `M3.9` macro above, this macro calls the underlying `M5` macro and if any spindles were activated, waits for them to stop. As above, the deceleration value will be reduced based on the rpm-change of the spindle.
+
+### Variable Spindle Speed Control
+
+Variable Spindle Speed Control (VSSC) constantly adjusts the speed of the spindle up and down over a set range to avoid resonance between the tool and the workpiece building up at constant RPMs. It can provide a quality boost in situations where resonances would otherwise occur.
+
+#### `M7000` - ENABLE VSSC
+
+Enable Variable Spindle Speed Control.
+
+#### `M7001` - DISABLE VSSC
+
+Disable Variable Spindle Speed Control
+
+---
+
+## Debugging
+
+### `M7600` - OUTPUT ALL KNOWN VARIABLES
+
+Sometimes it is necessary to debug MillenniumOS or RRF, and this macro allows outputting the macro variables that MillenniumOS uses in a manner that can be attached to tickets or discord messages to aid debugging. Call it with the `D1` parameter to enable additional RRF object model output that can help to debug the odder issues.

--- a/docs/millennium-os/manual/chapters/40_gcodes.md
+++ b/docs/millennium-os/manual/chapters/40_gcodes.md
@@ -288,6 +288,45 @@ In both modes, you can specify `O`, the overtravel distance, and `T`, the cleara
 
 `R0` suppresses reporting of the probe results, and `W` represents the WCS offset to set the origin on, if passed.
 
+### Base
+
+#### `G6512` - PROBE
+
+```gcode
+G6512 Lnnn [Inn] [Xnnn] [Ynnn] [Znnn] [Jnnn] [Knnn]
+```
+
+`G6512` is the underlying probing macro called by the higher-level probing cycle macros. It must be passed a target position in at least one axis (`X`, `Y` and `Z`), and a start position in at least the `Z` axes (`L`). It may also be passed a start position in `X` or `Y` axes. The unspecified axes for both start and target positions will default to the current machine co-ordinates.
+
+If `I` is not specified, the macro will trigger a guided manual probing cycle similar to the RRF jogging window, but only able to move towards or away from the target position. When complete, `G6512` will update the probe position in the `mosPCX`, `mosPCY` and `mosPCZ` global variables, adjusting for tool radius and deflection.
+
+#### `G6512.1` - AUTOMATED PROBE
+
+```gcode
+G6512.1 Inn [Xnnn] [Ynnn] [Znnn] [Rnn]
+```
+
+Probe a single point using an installed and connected touch probe. Target co-ordinates are specified using `X`, `Y` and `Z` and `R` can be used to override the number of retries rather than using the default value for the probe.
+
+Probe position will be reported in the `mosPCX`, `mosPCY` and `mosPCZ` global variables, with no compensation for tool radius or deflection. Probe variance will be stored in the `mosPVX`, `mosPVY` and `mosPVZ` variables.
+
+!!! warning
+    **DO NOT** call this macro directly - use `G6512`.
+
+#### `G6512.2` - MANUAL PROBE
+
+```gcode
+G6512.1 [Xnnn] [Ynnn] [Znnn]
+```
+
+Probe a single point using a manual jogging process. Target co-ordinates are specified using `X`, `Y` and `Z`.
+
+Probe position will be reported in the `mosPCX`, `mosPCY` and `mosPCZ` global variables, with no compensation for tool radius or deflection. Probe variance will be zero.
+
+
+!!! warning
+    **DO NOT** call this macro directly - use `G6512`.
+
 ---
 
 ## Tool Management

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
     - Introduction: millennium-os/manual/chapters/10_introduction.md
     - Installation: millennium-os/manual/chapters/20_installation.md
     - Usage: millennium-os/manual/chapters/30_usage.md
+    - G-Codes: millennium-os/manual/chapters/40_gcodes.md
   - "Contact Us": contact-us.md
 
 extra:


### PR DESCRIPTION
Added a gcode section which mirrors the `GCODES.md` doc from the MillenniumOS repo but with examples. 

Add some further information about usage, gotchas and other things that will help to further explain how MillenniumOS works.