### PR TITLE
Updating pre-flight doc to include checking spindle rotation

### DIFF
--- a/docs/milo/manual/chapters/110_pre_flight_checks.md
+++ b/docs/milo/manual/chapters/110_pre_flight_checks.md
@@ -79,8 +79,8 @@ Using a 6mm gauge pin (there should be one included in the LDO kit) draw adraw a
 
 Set your spindle to 10k RPM and then turn it off and watch the rotation of the line as the spindle slows down.  
 
-- If the line on the gauge pin is going from right to left (:leftwards_arrow_with_hook:), your spindle is rotating in the right direction.  
-- If the line is going from left to right (:arrow_right_hook:), the spindle is rotating in the wrong direction and you will need to flip two wires in the UVW set coming from the spindle.
+- If the line on the gauge pin is going from right to left ( <-- ), your spindle is rotating in the right direction.  
+- If the line is going from left to right ( --> ), the spindle is rotating in the wrong direction and you will need to flip two wires in the UVW set coming from the spindle.
 
 ---
 

--- a/docs/milo/manual/chapters/110_pre_flight_checks.md
+++ b/docs/milo/manual/chapters/110_pre_flight_checks.md
@@ -72,7 +72,7 @@ the line beginning with `M950` and change the value found after `L` to your maxi
 
 Before you can start cutting material, you need to make sure that the spindle is wired correctly and is rotating in the proper direction.
 
-Using a 6mm gauge pin (there should be one included in the LDO kit) draw adraw a stright line ~10mm down the side of the gauge pin and insert it into a 6mm collet in your spindle. 
+Using a 6mm gauge pin (included in most LDO kits) draw a stright line ~10mm down the side of the gauge pin and insert it into a 6mm collet in your spindle. 
 
 !!! note
     Make sure to snugly tighten the gauge pin in the spindle before processing to the next step

--- a/docs/milo/manual/chapters/110_pre_flight_checks.md
+++ b/docs/milo/manual/chapters/110_pre_flight_checks.md
@@ -75,7 +75,7 @@ Before you can start cutting material, you need to make sure that the spindle is
 Using a 6mm gauge pin (included in most LDO kits) draw a stright line ~10mm down the side of the gauge pin and insert it into a 6mm collet in your spindle. 
 
 !!! note
-    Make sure to snugly tighten the gauge pin in the spindle before processing to the next step
+    Make sure to snugly tighten the gauge pin in the spindle before proceeding to the next step!
 
 Start your spindle at the lowest speed and then turn it off and watch the rotation of the line on the gauge pin as the spindle slows down.  
 

--- a/docs/milo/manual/chapters/110_pre_flight_checks.md
+++ b/docs/milo/manual/chapters/110_pre_flight_checks.md
@@ -80,7 +80,7 @@ Using a 6mm gauge pin (included in most LDO kits) draw a stright line ~10mm down
 Start your spindle at the lowest speed and then turn it off and watch the rotation of the line on the gauge pin as the spindle slows down.  
 
 - If the line on the gauge pin is going from right to left ( <-- ), your spindle is rotating in the right direction.  
-- If the line is going from left to right ( --> ), the spindle is rotating in the wrong direction and you will need to flip two wires in the UVW set coming from the spindle.
+- If the line is going from left to right ( --> ), the spindle is rotating in the wrong direction. Swap any two spindle phase wires (UVW) at the VFD terminals (Swap UV, UW or VW).
 
 ---
 

--- a/docs/milo/manual/chapters/110_pre_flight_checks.md
+++ b/docs/milo/manual/chapters/110_pre_flight_checks.md
@@ -77,7 +77,7 @@ Using a 6mm gauge pin (included in most LDO kits) draw a stright line ~10mm down
 !!! note
     Make sure to snugly tighten the gauge pin in the spindle before processing to the next step
 
-Set your spindle to 10k RPM and then turn it off and watch the rotation of the line as the spindle slows down.  
+Start your spindle at the lowest speed and then turn it off and watch the rotation of the line on the gauge pin as the spindle slows down.  
 
 - If the line on the gauge pin is going from right to left ( <-- ), your spindle is rotating in the right direction.  
 - If the line is going from left to right ( --> ), the spindle is rotating in the wrong direction and you will need to flip two wires in the UVW set coming from the spindle.

--- a/docs/milo/manual/chapters/110_pre_flight_checks.md
+++ b/docs/milo/manual/chapters/110_pre_flight_checks.md
@@ -68,6 +68,22 @@ the line beginning with `M950` and change the value found after `L` to your maxi
 
 ---
 
+## Verifying Spindle Rotation
+
+Before you can start cutting material, you need to make sure that the spindle is wired correctly and is rotating in the proper direction.
+
+Using a 6mm gauge pin (there should be one included in the LDO kit) draw adraw a stright line ~10mm down the side of the gauge pin and insert it into a 6mm collet in your spindle. 
+
+!!! note
+    Make sure to snugly tighten the gauge pin in the spindle before processing to the next step
+
+Set your spindle to 10k RPM and then turn it off and watch the rotation of the line as the spindle slows down.  
+
+- If the line on the gauge pin is going from right to left (:leftwards_arrow_with_hook:), your spindle is rotating in the right direction.  
+- If the line is going from left to right (:arrow_right_hook:), the spindle is rotating in the wrong direction and you will need to flip two wires in the UVW set coming from the spindle.
+
+---
+
 ## Grease EVERYTHING
 
 If you have not done so yet make sure that all lead-screws and rails are appropriately greased and or oiled.


### PR DESCRIPTION
Checking spindle wiring via rotation is an important part of the pre-flight checks to reduce troubleshooting steps.
Adding in the steps to do so in the preflight checklist chapter.