### PR TITLE
Updating LDO Wiring guide linking

### DIFF
--- a/docs/milo/manual/chapters/100_assemble_electronics.md
+++ b/docs/milo/manual/chapters/100_assemble_electronics.md
@@ -3,7 +3,7 @@
 ![Assembled electronics area](../img/assemble_electronics/electronics_assembly.png){: .shadow}
 
 !!! info annotate "Are you building an LDO kit?"
-    LDO has written a fantastic supplementary guide for the wiring included with their kit which includes pre-cut, pre-crimped, and pre-soldered cables! If you're building an LDO kit check out their guide [here!](https://www.ldomotion.com/#/guide/Milo-CNC-V15-Wiring-Guide)
+    LDO has written a fantastic supplementary guide for the wiring included with their kit which includes pre-cut, pre-crimped, and pre-soldered cables! If you're building an LDO kit check out their guide [here!](https://ldomotion.com/guides/milo-cnc-v1-5-wiring-guide)
 
 ---
 

--- a/docs/milo/manual/chapters/100_assemble_electronics.md
+++ b/docs/milo/manual/chapters/100_assemble_electronics.md
@@ -3,7 +3,7 @@
 ![Assembled electronics area](../img/assemble_electronics/electronics_assembly.png){: .shadow}
 
 !!! info annotate "Are you building an LDO kit?"
-    LDO has written a fantastic supplementary guide for the wiring included with their kit which includes pre-cut, pre-crimped, and pre-soldered cables! If you're building an LDO kit check out their guide [here!](https://ldomotion.com/guides/milo-cnc-v1-5-wiring-guide)
+    LDO has written a fantastic supplementary guide for the wiring included with their kit which includes pre-cut, pre-crimped, and pre-soldered cables! If you're building an LDO kit check out their guide [here!](https://ldomotion.com/guides/milo-cnc-v15-wiring-guide)
 
 ---
 


### PR DESCRIPTION
The link that currently exists in the Milo docs links to a page that has been moved on the LDO site.
This change is to reflect the new URL instead of dropping to the LDO landing page.